### PR TITLE
Refactor frontend routing with React Router

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^5.0.2",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,114 +1,15 @@
-import React, { useState } from 'react';
-
-const categories = ['music', 'culture', 'sex-positive', 'workshop', 'talk', 'other'];
-
-function MatchingForm({ onSubmit }) {
-  const [form, setForm] = useState({
-    start_date: '', 
-    category: categories[0],
-    description: '',
-    venues: '',
-  });
-
-  const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    const request = {
-      start_date: form.start_date,
-      category: form.category,
-      description: form.description,
-      venues: form.venues.split(',').map(v => v.trim()).filter(Boolean),
-    };
-    onSubmit(request);
-  };
-
-  return (
-    <form onSubmit={handleSubmit}>
-      <label>
-        Date
-        <input type="date" name="start_date" value={form.start_date} onChange={handleChange} />
-      </label>
-      <label>
-        Category
-        <select name="category" value={form.category} onChange={handleChange}>
-          {categories.map(cat => (
-            <option key={cat} value={cat}>{cat}</option>
-          ))}
-        </select>
-      </label>
-      <label>
-        Description
-        <textarea name="description" value={form.description} onChange={handleChange} />
-      </label>
-      <label>
-        Venues (comma separated)
-        <input type="text" name="venues" value={form.venues} onChange={handleChange} />
-      </label>
-      <button type="submit">Find Events</button>
-    </form>
-  );
-}
-
-function EventCard({ event }) {
-  const [open, setOpen] = useState(false);
-  const image = event.Images && event.Images.length > 0 ? event.Images[0] : null;
-
-  return (
-    <div className="card">
-      {image && <img src={image} alt={event.Title} />}
-      <div className="card-content">
-        <h3 className="card-title">{event.Title}</h3>
-        <p className="card-caption">{event.Caption}</p>
-        <p className="card-venue">{event.Venue_name}</p>
-        <button className="toggle" onClick={() => setOpen(!open)}>
-          {open ? 'Hide' : 'Show'} description
-        </button>
-        {open && <p>{event.Description}</p>}
-      </div>
-    </div>
-  );
-}
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Home from './pages/Home.jsx';
+import SpotifyLinked from './pages/SpotifyLinked';
 
 export default function App() {
-  const [events, setEvents] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
-
-  const handleSubmit = async (request) => {
-    setLoading(true);
-    setError(null);
-    setEvents([]);
-    try {
-      const response = await fetch('/api/match', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(request),
-      });
-      if (!response.ok) {
-        throw new Error(`Request failed: ${response.status}`);
-      }
-      const data = await response.json();
-      setEvents(data);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
-    <div className="container">
-      <h1>Gigs Near Me</h1>
-      <MatchingForm onSubmit={handleSubmit} />
-      {loading && <p>Loading...</p>}
-      {error && <p style={{ color: 'red' }}>{error}</p>}
-      {events.map(event => (
-        <EventCard key={`${event.Source_name}-${event.Title}`} event={event} />
-      ))}
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/spotify/linked" element={<SpotifyLinked />} />
+      </Routes>
+    </BrowserRouter>
   );
 }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,0 +1,116 @@
+import React, { useState } from 'react';
+
+const categories = ['music', 'culture', 'sex-positive', 'workshop', 'talk', 'other'];
+
+function MatchingForm({ onSubmit }) {
+  const [form, setForm] = useState({
+    start_date: '',
+    category: categories[0],
+    description: '',
+    venues: '',
+  });
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const request = {
+      start_date: form.start_date,
+      category: form.category,
+      description: form.description,
+      venues: form.venues.split(',').map((v) => v.trim()).filter(Boolean),
+    };
+    onSubmit(request);
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <label>
+        Date
+        <input type="date" name="start_date" value={form.start_date} onChange={handleChange} />
+      </label>
+      <label>
+        Category
+        <select name="category" value={form.category} onChange={handleChange}>
+          {categories.map((cat) => (
+            <option key={cat} value={cat}>
+              {cat}
+            </option>
+          ))}
+        </select>
+      </label>
+      <label>
+        Description
+        <textarea name="description" value={form.description} onChange={handleChange} />
+      </label>
+      <label>
+        Venues (comma separated)
+        <input type="text" name="venues" value={form.venues} onChange={handleChange} />
+      </label>
+      <button type="submit">Find Events</button>
+    </form>
+  );
+}
+
+function EventCard({ event }) {
+  const [open, setOpen] = useState(false);
+  const image = event.Images && event.Images.length > 0 ? event.Images[0] : null;
+
+  return (
+    <div className="card">
+      {image && <img src={image} alt={event.Title} />}
+      <div className="card-content">
+        <h3 className="card-title">{event.Title}</h3>
+        <p className="card-caption">{event.Caption}</p>
+        <p className="card-venue">{event.Venue_name}</p>
+        <button className="toggle" onClick={() => setOpen(!open)}>
+          {open ? 'Hide' : 'Show'} description
+        </button>
+        {open && <p>{event.Description}</p>}
+      </div>
+    </div>
+  );
+}
+
+export default function Home() {
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async (request) => {
+    setLoading(true);
+    setError(null);
+    setEvents([]);
+    try {
+      const response = await fetch('/api/match', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+      });
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+      const data = await response.json();
+      setEvents(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1>Gigs Near Me</h1>
+      <MatchingForm onSubmit={handleSubmit} />
+      {loading && <p>Loading...</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      {events.map((event) => (
+        <EventCard key={`${event.Source_name}-${event.Title}`} event={event} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/SpotifyLinked.tsx
+++ b/frontend/src/pages/SpotifyLinked.tsx
@@ -1,5 +1,6 @@
 // src/pages/SpotifyLinked.tsx
 import React, { useEffect, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
 import { getJSON } from "../api";
 
 type SavedTracksResponse = {
@@ -14,24 +15,23 @@ export default function SpotifyLinked() {
     const [status, setStatus] = useState<"idle" | "ok" | "err">("idle");
     const [err, setErr] = useState<string>("");
     const [sample, setSample] = useState<Array<string>>([]);
+    const [searchParams] = useSearchParams();
 
     useEffect(() => {
-        // If you pass ?error=... from backend on failure, show it
-        const params = new URLSearchParams(window.location.search);
-        const e = params.get("error");
-        if (e) {
+        const error = searchParams.get("error");
+        if (error) {
             setStatus("err");
-            setErr(e);
+            setErr(error);
         } else {
             setStatus("ok");
         }
-    }, []);
+    }, [searchParams]);
 
     const fetchLiked = async () => {
         try {
             const data = await getJSON<SavedTracksResponse>("/api/spotify/liked");
             const names = (data.items || []).slice(0, 5).map(
-                (it) => `${it.track.name} — ${it.track.artists.map(a => a.name).join(", ")}`
+                (it) => `${it.track.name} — ${it.track.artists.map((a) => a.name).join(", ")}`
             );
             setSample(names);
         } catch (e: any) {
@@ -60,7 +60,7 @@ export default function SpotifyLinked() {
                 <>
                     <h1>Spotify link failed ❌</h1>
                     <p style={{ color: "crimson" }}>{err}</p>
-                    <a href="/">Back</a>
+                    <Link to="/">Back</Link>
                 </>
             ) : null}
         </div>


### PR DESCRIPTION
## Summary
- add react-router-dom and wrap the app with a BrowserRouter
- move the matching form into a dedicated Home page and register routes for Home and SpotifyLinked
- update the SpotifyLinked page to use React Router utilities for search params and navigation

## Testing
- npm run build *(fails: missing react-router-dom package because registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08cbc50b08322aa156473e7f82556